### PR TITLE
Kaffe and Kaffe.Producer do not depend on config lib

### DIFF
--- a/lib/kaffe.ex
+++ b/lib/kaffe.ex
@@ -9,14 +9,14 @@ defmodule Kaffe do
 
   require Logger
 
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
+  def start(_type, args) do
     Logger.debug("event#start=#{__MODULE__}")
 
-    if Application.get_env(:kaffe, :producer) do
+    start_producer? = Keyword.get(args, :start_producer?) || Application.get_env(:kaffe, :producer)
+
+    if start_producer? do
       Logger.debug("event#start_producer_client=#{__MODULE__}")
-      Kaffe.Producer.start_producer_client()
+      Kaffe.Producer.start_producer_client(args)
     end
 
     children = []

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -27,7 +27,11 @@ defmodule Kaffe.Producer do
   ## public api
   ## -------------------------------------------------------------------------
 
-  def start_producer_client do
+  def start_producer_client(opts \\ []) do
+    client_name = Keyword.get(opts, :client_name) || client_name()
+    endpoints = Keyword.get(opts, :endpoints) || config().endpoints
+    producer_config = Keyword.get(opts, :producer_config) || config().producer_config
+
     @kafka.start_client(config().endpoints, client_name(), config().producer_config)
   end
 
@@ -132,10 +136,9 @@ defmodule Kaffe.Producer do
         )
 
         @kafka.produce_sync(client_name(), topic, partition, key, value)
+
       error ->
-        Logger.warn(
-          "event#produce topic=#{topic} key=#{key} error=#{inspect(error)}"
-        )
+        Logger.warn("event#produce topic=#{topic} key=#{key} error=#{inspect(error)}")
 
         error
     end


### PR DESCRIPTION
With these changes it will be much easier to implement a library on top
of Kaffe that can be started directly in the supervison tree instead of
depending on shared config